### PR TITLE
Fix offset on Product Area Info FRU

### DIFF
--- a/src/drvMch.c
+++ b/src/drvMch.c
@@ -462,7 +462,7 @@ mchFruProdDataGet(FruProd prod, uint8_t *raw, unsigned *offset)
 {
 	if ( 0 != (*offset = 8*raw[FRU_DATA_COMMON_HEADER_OFFSET + FRU_DATA_COMMON_HEADER_PROD_AREA_OFFSET]) ) {
 
-		prod->lang = raw[*offset + FRU_DATA_BOARD_AREA_LANG_OFFSET];
+		prod->lang = raw[*offset + FRU_DATA_PROD_AREA_LANG_OFFSET];
 
 		*offset += FRU_DATA_PROD_AREA_MANUF_LENGTH_OFFSET;
 


### PR DESCRIPTION
The offset used to read the product information data in FRU is wrong and causes the IOC to ask for (and retrieve) wrong data.