### PR TITLE
Include SDR max/min reading field

### DIFF
--- a/src/devMch.c
+++ b/src/devMch.c
@@ -712,9 +712,12 @@ int      s = 0, inst;
 			if ( sdr->str )
 				strcpy( pai->desc, sdr->str );
 
-			if ( sdr->recType == SDR_TYPE_FULL_SENSOR )
+			if ( sdr->recType == SDR_TYPE_FULL_SENSOR ) {
 				sensThresh( sdr, sens, &pai->lolo, &pai->llsv, &pai->low, &pai->lsv, 
 					    &pai->high, &pai->hsv, &pai->hihi, &pai->hhsv, pai->name );
+				pai->hopr = sensorConversion( sdr, sdr->maxReading, pai->name );
+				pai->lopr = sensorConversion( sdr, sdr->minReading, pai->name );
+			}	
 			sens->cnfg = 1;
 		}
 

--- a/src/drvMch.c
+++ b/src/drvMch.c
@@ -1266,6 +1266,8 @@ int m = 0, b = 0;
 		sdr->nominal    = raw[SDR_NOMINAL_OFFSET];   
 		sdr->normMax    = raw[SDR_NORM_MAX_OFFSET];   
 		sdr->normMin    = raw[SDR_NORM_MIN_OFFSET];   
+		sdr->maxReading = raw[SDR_MAX_READING_OFFSET];   
+		sdr->minReading = raw[SDR_MIN_READING_OFFSET];   
 		sdr->strLength  = raw[SDR_STR_LENGTH_OFFSET];    
 
 		m = SENSOR_CONV_M_B( sdr->M, sdr->MTol );

--- a/src/ipmiDef.h
+++ b/src/ipmiDef.h
@@ -101,6 +101,8 @@ typedef struct SdrFullRec_ {
 	uint8_t      nominal;       /* Nominal reading (raw units) */
 	uint8_t      normMax;       /* Normal maximum (raw units) */
 	uint8_t      normMin;       /* Normal minimum (raw units) */
+	uint8_t      maxReading;    /* Maximum reading value (raw units) */
+	uint8_t      minReading;    /* Minimum reading value (raw units) */
 	char         str[17];       /* Sensor ID string, 16 bytes maximum */
 	/* calculated values, only supported for Full SDR */
 	int          m;             
@@ -650,6 +652,8 @@ extern size_t IPMI_MSG1_LENGTH;
 #define SDR_NOMINAL_OFFSET      31
 #define SDR_NORM_MAX_OFFSET     32
 #define SDR_NORM_MIN_OFFSET     33
+#define SDR_MAX_READING_OFFSET  34
+#define SDR_MIN_READING_OFFSET  35
 #define SDR_STR_LENGTH_OFFSET   47
 #define SDR_STR_OFFSET          48
 /*...more...*/


### PR DESCRIPTION
Reading the max/min reading from SDR fields allows the IOC to correctly populate the LOPR and HOPR fields for Analog Input sensors.